### PR TITLE
fix undefined method TCG\Voyager\Voyager::canOrFail()

### DIFF
--- a/src/Controllers/ExtendedBreadFormFieldsMediaController.php
+++ b/src/Controllers/ExtendedBreadFormFieldsMediaController.php
@@ -28,9 +28,11 @@ class ExtendedBreadFormFieldsMediaController extends VoyagerMediaController
     
                 // GET THE DataType based on the slug
                 $dataType = Voyager::model('DataType')->where('slug', '=', $slug)->first();
-    
+
                 // Check permission
-                Voyager::canOrFail('delete_'.$dataType->name);
+                if (!auth()->user()->hasPermission('delete_'.$dataType->name)) {
+                    throw new Exception(__('voyager::generic.error_deleting'), 403);
+                }
     
                 // Load model and find record
                 $model = app($dataType->model_name);


### PR DESCRIPTION
Fixing error during deleting of image due to using old canOrFail method

https://voyager.readme.io/docs/permissions

Error:

production.ERROR: Call to undefined method TCG\Voyager\Voyager::canOrFail() {"userId":3,"exception":"[object] (Symfony\\Component\\Debug\\Exception\\FatalThrowableError(code: 0): Call to undefined method TCG\\Voyager\\Voyager::canOrFail() at vendor/laravel/framework/src/Illuminate/Support/Facades/Facade.php:237)

This error happens on voyager v1.2.6.